### PR TITLE
Respect explicit type annotations on test/fixture parameters

### DIFF
--- a/src/main/java/com/y4kstudios/pytestimp/fixtures/LambdaFixtureReferenceContributor.kt
+++ b/src/main/java/com/y4kstudios/pytestimp/fixtures/LambdaFixtureReferenceContributor.kt
@@ -101,6 +101,11 @@ object LambdaFixtureTypeProvider : PyTypeProviderBase() {
             return null
         }
 
+        val explicitType = param.getArgumentType(context)
+        if (explicitType != null) {
+            return Ref(explicitType)
+        }
+
         return (
             param.references
                 .firstOrNull { it is LambdaFixtureReference || it is PyTestFixtureReference }


### PR DESCRIPTION
This PR alters the type provider to favour explicitly-declared annotations on parameters over inferred type of the corresponding fixture.

Previously, the `an_int` parameter in the snippet below would be typed as `int`, despite being explicitly declared as `str`. This PR resolves that issue, and the `an_int` is typed as `str`

```py
an_int = static_fixture(123)

def test_stuff(an_int: str):
    # ...
```

Closes #2 